### PR TITLE
Fixes softlock when attempting to land ship on planets with custom weather

### DIFF
--- a/Patches/LungProp.cs
+++ b/Patches/LungProp.cs
@@ -12,9 +12,17 @@ namespace MeteoMultiplier.Patches
         private static void Prefix(LungProp __instance)
         {
             var currentWeather = __instance.roundManager.currentLevel.currentWeather;
-            if(Plugin.MultiplyApparatusEnabled.Value && Plugin.Multipliers.ContainsKey(currentWeather))
+
+            if (Plugin.MultiplyApparatusEnabled.Value)
             {
-                __instance.SetScrapValue((int)(__instance.scrapValue * Plugin.Multipliers[currentWeather].Value));
+                if (Plugin.Multipliers.ContainsKey(currentWeather))
+                {
+                    __instance.SetScrapValue((int)(__instance.scrapValue * Plugin.Multipliers[currentWeather].Value));
+                }
+                else
+                {
+                    __instance.SetScrapValue((int)(__instance.scrapValue * Plugin.Multipliers[Plugin.DEFAULT_WEATHER].Value));
+                }
             }
         }
     }

--- a/Patches/LungProp.cs
+++ b/Patches/LungProp.cs
@@ -11,9 +11,9 @@ namespace MeteoMultiplier.Patches
     {
         private static void Prefix(LungProp __instance)
         {
-            if(Plugin.MultiplyApparatusEnabled.Value)
+            var currentWeather = __instance.roundManager.currentLevel.currentWeather;
+            if(Plugin.MultiplyApparatusEnabled.Value && Plugin.Multipliers.ContainsKey(currentWeather))
             {
-                var currentWeather = __instance.roundManager.currentLevel.currentWeather;
                 __instance.SetScrapValue((int)(__instance.scrapValue * Plugin.Multipliers[currentWeather].Value));
             }
         }

--- a/Patches/RoundManager.cs
+++ b/Patches/RoundManager.cs
@@ -11,9 +11,9 @@ namespace MeteoMultiplier.Patches
         private static void Prefix(RoundManager __instance)
         {
             LevelWeatherType currentWeather = __instance.currentLevel.currentWeather;
-            if (Plugin.MultipliersEnabled.Value)
+            if (Plugin.MultipliersEnabled.Value && Plugin.Multipliers.ContainsKey(currentWeather))
                 __instance.scrapValueMultiplier = Plugin.Multipliers[currentWeather].Value;
-            if (Plugin.SpawnMultipliersEnabled.Value)
+            if (Plugin.SpawnMultipliersEnabled.Value && Plugin.SpawnMultipliers.ContainsKey(currentWeather))
                 __instance.scrapAmountMultiplier = Plugin.SpawnMultipliers[currentWeather].Value;
         }
     }

--- a/Patches/RoundManager.cs
+++ b/Patches/RoundManager.cs
@@ -11,10 +11,30 @@ namespace MeteoMultiplier.Patches
         private static void Prefix(RoundManager __instance)
         {
             LevelWeatherType currentWeather = __instance.currentLevel.currentWeather;
-            if (Plugin.MultipliersEnabled.Value && Plugin.Multipliers.ContainsKey(currentWeather))
-                __instance.scrapValueMultiplier = Plugin.Multipliers[currentWeather].Value;
-            if (Plugin.SpawnMultipliersEnabled.Value && Plugin.SpawnMultipliers.ContainsKey(currentWeather))
-                __instance.scrapAmountMultiplier = Plugin.SpawnMultipliers[currentWeather].Value;
+
+            if (Plugin.MultipliersEnabled.Value)
+            {
+                if (Plugin.Multipliers.ContainsKey(currentWeather))
+                {
+                    __instance.scrapValueMultiplier = Plugin.Multipliers[currentWeather].Value;
+                }
+                else
+                {
+                    __instance.scrapValueMultiplier = Plugin.Multipliers[Plugin.DEFAULT_WEATHER].Value;
+                }
+            }
+
+            if (Plugin.SpawnMultipliersEnabled.Value)
+            {
+                if (Plugin.SpawnMultipliers.ContainsKey(currentWeather))
+                {
+                    __instance.scrapAmountMultiplier = Plugin.SpawnMultipliers[currentWeather].Value;
+                }
+                else
+                {
+                    __instance.scrapAmountMultiplier = Plugin.SpawnMultipliers[Plugin.DEFAULT_WEATHER].Value;
+                }
+            }
         }
     }
 }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -15,6 +15,8 @@ namespace MeteoMultiplier
         public static ConfigEntry<bool> SpawnMultipliersEnabled;
         public static ConfigEntry<bool> MultiplyApparatusEnabled;
 
+        public const LevelWeatherType DEFAULT_WEATHER = LevelWeatherType.None;
+
         private void Awake()
         {
             Logger.LogInfo($"Plugin {PluginInfo.PLUGIN_GUID} is loaded!");

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -15,7 +15,6 @@ namespace MeteoMultiplier
         public static ConfigEntry<bool> SpawnMultipliersEnabled;
         public static ConfigEntry<bool> MultiplyApparatusEnabled;
 
-
         private void Awake()
         {
             Logger.LogInfo($"Plugin {PluginInfo.PLUGIN_GUID} is loaded!");


### PR DESCRIPTION
I encountered this problem when running MeteoWeather alongside [Whimsical Weather](https://thunderstore.io/c/lethal-company/p/Bobbie/WhimsicalWeather/).

```
[Error  : Unity Log] KeyNotFoundException: The given key '<color=#FF00FF>Whimsical</color>' was not present in the dictionary.
Stack trace:
System.Collections.Generic.Dictionary`2[TKey,TValue].get_Item (TKey key) (at <787acc3c9a4c471ba7d971300105af24>:IL_001E)
MeteoMultiplier.Patches.SpawnScrapInLevelPatches.Prefix (RoundManager __instance) (at <4d156d01b7dd4f6aa903e63153464984>:IL_0018)
(wrapper dynamic-method) RoundManager.DMD<RoundManager::SpawnScrapInLevel>(RoundManager)
RoundManager.GeneratedFloorPostProcessing () (at <44743d9474784365a095189c76175301>:IL_0009)
RoundManager+<LoadNewLevelWait>d__106.MoveNext () (at <44743d9474784365a095189c76175301>:IL_013C)
UnityEngine.SetupCoroutine.InvokeMoveNext (System.Collections.IEnumerator enumerator, System.IntPtr returnValueAddress) (at <e27997765c1848b09d8073e5d642717a>:IL_0026)
```

This fix does not add support for multipliers for custom weather, but it stops the game from hanging. All multipliers are disabled on planets with custom weather.