### PR TITLE
Fix Apparatus Value

### DIFF
--- a/Patches/LungProp.cs
+++ b/Patches/LungProp.cs
@@ -12,17 +12,9 @@ namespace MeteoMultiplier.Patches
         private static void Prefix(LungProp __instance)
         {
             var currentWeather = __instance.roundManager.currentLevel.currentWeather;
-
-            if (Plugin.MultiplyApparatusEnabled.Value)
+            if (Plugin.MultiplyApparatusEnabled.Value && Plugin.Multipliers.ContainsKey(currentWeather))
             {
-                if (Plugin.Multipliers.ContainsKey(currentWeather))
-                {
-                    __instance.SetScrapValue((int)(__instance.scrapValue * Plugin.Multipliers[currentWeather].Value));
-                }
-                else
-                {
-                    __instance.SetScrapValue((int)(__instance.scrapValue * Plugin.Multipliers[Plugin.DEFAULT_WEATHER].Value));
-                }
+                __instance.SetScrapValue((int)(__instance.scrapValue * (Plugin.Multipliers[currentWeather].Value + 1)));
             }
         }
     }


### PR DESCRIPTION
The apparatus value was reduced, not increased (https://github.com/Fredolx/lc-meteo-multiplier/issues/5). This PR fixes this issue and I also removed the else added by https://github.com/Fredolx/lc-meteo-multiplier/pull/3 since it's not needed.